### PR TITLE
support legacy "encoding" if "valueEncoding" is not provided.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,10 @@ Codec.prototype._keyEncoding = function(opts, batchOpts){
 };
 
 Codec.prototype._valueEncoding = function(opts, batchOpts){
-  return this._encoding(batchOpts && batchOpts.valueEncoding
-    || opts && opts.valueEncoding
-    || this.opts.valueEncoding);
+  return this._encoding(
+    batchOpts && (batchOpts.valueEncoding || batchOpts.encoding)
+    || opts && (opts.valueEncoding || opts.encoding)
+    || (this.opts.valueEncoding || this.opts.encoding));
 };
 
 Codec.prototype.encodeKey = function(key, opts, batchOpts){

--- a/test/batch.js
+++ b/test/batch.js
@@ -27,3 +27,30 @@ test('batch', function(t){
   t.end();
 });
 
+
+test('batch - legacy', function(t){
+  var codec = new Codec({});
+  var ops = [
+    { type: 'put', key: 'string', value: 'string', encoding: 'utf8' },
+    { type: 'put', key: 'json', value: {} }
+  ];
+  var opsSerialized = JSON.stringify(ops);
+
+  var encoded = codec.encodeBatch(ops, { encoding: 'json' });
+
+  t.equal(opsSerialized, JSON.stringify(ops), 'ops not changed');
+
+  t.deepEqual(encoded, [
+    { type: 'put', key: 'string', value: 'string' },
+    { type: 'put', key: 'json', value: '{}' }
+  ]);
+
+  encoded = codec.encodeBatch(ops);
+  t.deepEqual(encoded, [
+    { type: 'put', key: 'string', value: 'string' },
+    { type: 'put', key: 'json', value: {} }
+  ]);
+
+  t.end();
+});
+

--- a/test/decoder.js
+++ b/test/decoder.js
@@ -34,3 +34,37 @@ test('createStreamDecoder', function(t){
     t.end();
   });
 });
+
+test('createStreamDecoder - legacy', function(t){
+  var codec = new Codec({ keyEncoding: 'hex' });
+
+  t.test('keys and values', function(t){
+    var decoder = codec.createStreamDecoder({
+      encoding: 'json',
+      keys: true,
+      values: true
+    });
+    t.deepEqual(decoder(new Buffer('hey'), '"you"'), {
+      key: '686579',
+      value: 'you'
+    });
+    t.end();
+  });
+
+  t.test('keys', function(t){
+    var decoder = codec.createStreamDecoder({
+      keys: true
+    });
+    t.equal(decoder(new Buffer('hey')), '686579');
+    t.end();
+  });
+
+  t.test('values', function(t){
+    var decoder = codec.createStreamDecoder({
+      encoding: 'hex',
+      values: true
+    });
+    t.equal(decoder(null, new Buffer('hey')), '686579');
+    t.end();
+  });
+});

--- a/test/kv.js
+++ b/test/kv.js
@@ -69,3 +69,37 @@ test('decode value', function(t){
   t.end();
 });
 
+test('encode value - legacy', function(t){
+  var codec = new Codec({ encoding: 'hex' });
+
+  var buf = codec.encodeValue('686579', {});
+  t.equal(buf.toString(), 'hey');
+
+  buf = codec.encodeValue('686579');
+  t.equal(buf.toString(), 'hey');
+
+  buf = codec.encodeValue('686579', {
+    encoding: 'binary'
+  });
+  t.equal(buf.toString(), '686579');
+
+  t.end();
+});
+
+test('decode value - legacy', function(t){
+  var codec = new Codec({ encoding: 'hex' });
+
+  var buf = codec.decodeValue(new Buffer('hey'), {});
+  t.equal(buf, '686579');
+
+  buf = codec.decodeValue(new Buffer('hey'));
+  t.equal(buf, '686579');
+
+  buf = codec.decodeValue(new Buffer('hey'), {
+    encoding: 'binary'
+  });
+  t.equal(buf.toString(), 'hey');
+
+  t.end();
+});
+


### PR DESCRIPTION
I'd like add support for the legacy encoding default behavior, which I had used in a bunch of modules.
I can see the value of tidying up the api a bit, but i just don't think that making a breaking change for such a little thing (a few lines removed) that doesn't make significant improvements, or at least enable those, just isn't really worthwhile if you have to update a bunch of things.
