### PR TITLE
Add "none" encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ var codec = new Codec(db.options);
 }
 ```
 
+  Currently supported encodings:
+
+  - utf8
+  - json
+  - binary
+  - hex
+  - ascii
+  - base64
+  - ucs2
+  - ucs-2
+  - utf16le
+  - utf-16le
+  - none (bypass level-codec)
+
 ## Publishers
 
 * [@juliangruber](https://github.com/juliangruber)

--- a/lib/encodings.js
+++ b/lib/encodings.js
@@ -28,7 +28,7 @@ exports.binary = {
   type: 'binary'
 };
 
-exports.id = {
+exports.none = {
   encode: function(data){
     return data;
   },
@@ -38,6 +38,8 @@ exports.id = {
   buffer: false,
   type: 'id'
 };
+
+exports.id = exports.none;
 
 var bufferEncodings = [
   'hex',

--- a/test/kv.js
+++ b/test/kv.js
@@ -15,6 +15,11 @@ test('encode key', function(t){
   });
   t.equal(buf.toString(), '686579');
 
+  buf = codec.encodeKey({ foo: 'bar' }, {
+    keyEncoding: 'none'
+  });
+  t.deepEqual(buf, { foo: 'bar' });
+
   t.end();
 });
 


### PR DESCRIPTION
the name `"id"` (for "identify") is quite functional, so i renamed it to `"none"` but added an alias as well so it's no breaking change.

also added some documentation

cc @ralphtheninja 
