### PR TITLE
Fix/utf8 decoding

### DIFF
--- a/lib/encodings.js
+++ b/lib/encodings.js
@@ -5,7 +5,11 @@ exports.utf8 = exports['utf-8'] = {
       ? data
       : String(data);
   },
-  decode: identity,
+  decode: function(data){
+    return typeof data === 'string'
+      ? data
+      : String(data)
+  },
   buffer: false,
   type: 'utf8'
 };

--- a/test/kv.js
+++ b/test/kv.js
@@ -71,6 +71,11 @@ test('decode value', function(t){
   });
   t.equal(buf.toString(), 'hey');
 
+  buf = codec.decodeValue(new Buffer('hey'), {
+    valueEncoding: 'utf8'
+  });
+  t.equal(buf, 'hey');
+
   t.end();
 });
 


### PR DESCRIPTION
The utf-8 encoding should always return strings. This is a major change, but required for correctness. I noticed this bug working on level/encoding-down.