### PR TITLE
encodings: use identity function consistently

### DIFF
--- a/lib/encodings.js
+++ b/lib/encodings.js
@@ -1,4 +1,3 @@
-
 exports.utf8 = exports['utf-8'] = {
   encode: function(data){
     return isBinary(data)
@@ -33,12 +32,8 @@ exports.binary = {
 };
 
 exports.none = {
-  encode: function(data){
-    return data;
-  },
-  decode: function(data){
-    return data;
-  },
+  encode: identity,
+  decode: identity,
   buffer: false,
   type: 'id'
 };
@@ -79,4 +74,3 @@ function isBinary(data){
     || data === null
     || Buffer.isBuffer(data);
 }
-


### PR DESCRIPTION
Just something I noticed that made me double take to see if they were the same,   especially when comparing `binary` and `none`.