### PR TITLE
remove unused this.encodings

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ module.exports = Codec;
 
 function Codec(opts){
   this.opts = opts || {};
-  this.encodings = encodings;
 }
 
 Codec.prototype._encoding = function(encoding){


### PR DESCRIPTION
Is this intentional?

Also,  why use `this._encoding(...)` if no `this` context is needed?