### PR TITLE
feat(typings): generic encoder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 
 declare namespace codec {
-  interface CodecEncoder {
-    encode: (val: any) => any;
-    decode: (val: any) => any;
+  interface CodecEncoder<I=any> {
+    encode: (val: I) => any
+    decode: (val: any) => I
     buffer: boolean
     type: string
   }
 
-  interface CodecOptions {
-    keyEncoding?: string | CodecEncoder
-    valueEncoding?: string | CodecEncoder
+  interface CodecOptions<K=any, V=any> {
+    keyEncoding?: string | CodecEncoder<K>
+    valueEncoding?: string | CodecEncoder<V>
   }
 
   interface Codec {


### PR DESCRIPTION
_non-breaking_ 

Allow typing the _encode_ **from** / _decode_ **to** type

defaults to `any` (existing behavior)

I've purposefully left the _encode_ **to** / _decode_ **from** type as `any` to keep things simple