### PR TITLE
Restore: fix utf-8 encoding returning buffers

### DIFF
--- a/lib/encodings.js
+++ b/lib/encodings.js
@@ -2,7 +2,11 @@ exports.utf8 = exports['utf-8'] = {
   encode: function (data) {
     return isBinary(data) ? data : String(data)
   },
-  decode: identity,
+  decode: function (data) {
+    return typeof data === 'string'
+      ? data
+      : String(data)
+  },
   buffer: false,
   type: 'utf8'
 }

--- a/test/kv.js
+++ b/test/kv.js
@@ -71,6 +71,11 @@ test('decode value', function (t) {
   })
   t.equal(buf.toString(), 'hey')
 
+  buf = codec.decodeValue(Buffer.from('hey'), {
+    valueEncoding: 'utf8'
+  })
+  t.equal(buf, 'hey')
+
   t.end()
 })
 


### PR DESCRIPTION
History:

- The utf8 encoding is supposed to return a string. That's always been the case AFAIK and makes perfect sense. Stores like `leveldown` however, may return data as a buffer and we've had to account for this. Let's call this the **_maybe-string_ problem**. The primary solution has been to pass `leveldown` a boolean `*asBuffer` option. If false, `leveldown` returns data as a string.
- When we separated the encoding logic from `levelup` into `encoding-down`, we didn't take the `*asBuffer` options into account (we didn't realize that at the time). Some stores would return a buffer instead of a string. To deal with that, coercion to string was added to `level-codec` in https://github.com/Level/codec/pull/12 (7.0.0).
- Coercion to string was removed in https://github.com/Level/codec/pull/23 (8.0.0) because the `*asBuffer` logic was restored in https://github.com/Level/encoding-down/pull/19; we thought coercion was no longer necessary.

This PR restores the coercion, to work around an ecosystem quirk: `leveldown` and `memdown` handle strings and buffers differently. While `leveldown` stores both types as a byte array (meaning you can put a buffer and get back a string if so desired, and vice versa), `memdown` stores them as-is (meaning if you put a buffer, you'll get back a buffer; if you put a string, you'll get back a string - simplified). This leads to unexpected behavior.

Another issue (which won't be fixed by this PR but is very relevant) is that `memdown` isn't able to compare a string key to a buffer key (or any other type for that matter); you can only safely use one key type in your db. Possible solutions are discussed in https://github.com/Level/memdown/issues/186. Let's call this the **_mixed-type_ problem**. It is relevant because:

- One proposed solution will make `memdown` behave like `leveldown` and thus remove the need for this `level-codec` PR. Before you say "that sounds like the simplest solution", wait...
- Another proposed solution will make `memdown` behave like `level-js` which doesn't have the _maybe-string_ problem either, albeit for a different reason. It treats strings and buffers as distinct keys and values, even if their bytes are the same. Arguably - especially when viewed outside of the historical context of Level - this is the least-surprising behavior because you get back what you store. Working with binary data is a distinctly different use case from working with utf8 strings. You'll only sometimes have the need to process utf8 data as binary, which you can still do.

So, fixing the _mixed-type_ problem might also fix the _maybe-string_ problem, but we could still choose to merge this PR as a short- to medium-term solution.