### PR TITLE
chore: update buffer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "npm run dependency-check"
   },
   "dependencies": {
-    "buffer": "^5.6.0"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
Updates `Buffer` to the latest version as having multiple versions in
the dep tree causes quite a lot of bundle bloat when run in browsers!

Refs: https://github.com/Level/abstract-leveldown/pull/373